### PR TITLE
Fix issue with fetching sample files in EnhancedAudioManager

### DIFF
--- a/src/core/audio/EnhancedAudioManager.ts
+++ b/src/core/audio/EnhancedAudioManager.ts
@@ -42,11 +42,11 @@ export class EnhancedAudioManager extends AudioBase {
 
         // Default samples to load
         this.defaultSamples = [
-            { name: 'kick', url: '/samples/kick.wav', baseNote: 'C3' },
-            { name: 'snare', url: '/samples/snare.wav', baseNote: 'D3' },
-            { name: 'hihat', url: '/samples/hihat.wav', baseNote: 'F#3' },
-            { name: 'bass', url: '/samples/bass.wav', baseNote: 'C2' },
-            { name: 'lead', url: '/samples/lead.wav', baseNote: 'C4' }
+            { name: 'kick', url: '/audio-viz/samples/kick.wav', baseNote: 'C3' },
+            { name: 'snare', url: '/audio-viz/samples/snare.wav', baseNote: 'D3' },
+            { name: 'hihat', url: '/audio-viz/samples/hihat.wav', baseNote: 'F#3' },
+            { name: 'bass', url: '/audio-viz/samples/bass.wav', baseNote: 'C2' },
+            { name: 'lead', url: '/audio-viz/samples/lead.wav', baseNote: 'C4' }
         ];
     }
 


### PR DESCRIPTION
Corrected sample file paths to include base path `/audio-viz/`, ensuring samples are loaded correctly from the public directory when using Vite. This fixes the failed fetch errors for audio samples and allows successful initialization of the audio manager. Closes #123.



Created with [**Solver**](https://solverai.com)