### PR TITLE
Fix sample loading path and cleanup redundant directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,11 +45,6 @@ coverage/
 .DS_Store
 Thumbs.db
 
-# Audio files
-samples/*.wav
-samples/*.mp3
-samples/*.ogg
-
 # Temporary files
 *.tmp
 *.temp

--- a/src/core/audio/EnhancedAudioManager.ts
+++ b/src/core/audio/EnhancedAudioManager.ts
@@ -42,11 +42,11 @@ export class EnhancedAudioManager extends AudioBase {
 
         // Default samples to load
         this.defaultSamples = [
-            { name: 'kick', url: '/samples/kick.wav', baseNote: 'C3' },
-            { name: 'snare', url: '/samples/snare.wav', baseNote: 'D3' },
-            { name: 'hihat', url: '/samples/hihat.wav', baseNote: 'F#3' },
-            { name: 'bass', url: '/samples/bass.wav', baseNote: 'C2' },
-            { name: 'lead', url: '/samples/lead.wav', baseNote: 'C4' }
+            { name: 'kick', url: 'samples/kick.wav', baseNote: 'C3' },
+            { name: 'snare', url: 'samples/snare.wav', baseNote: 'D3' },
+            { name: 'hihat', url: 'samples/hihat.wav', baseNote: 'F#3' },
+            { name: 'bass', url: 'samples/bass.wav', baseNote: 'C2' },
+            { name: 'lead', url: 'samples/lead.wav', baseNote: 'C4' }
         ];
     }
 


### PR DESCRIPTION
Resolved an issue with the loading path for audio samples by updating to relative paths. Cleaned up redundant sample directories and removed unnecessary entries from the .gitignore file. Focus on keeping samples in `public/samples` to streamline access and development. 🛠️



Created with [**Solver**](https://solverai.com)