### PR TITLE
Set default low-energy movement in StickFigure and ParticleWave scenes

### DIFF
--- a/src/scenes/ParticleWave.ts
+++ b/src/scenes/ParticleWave.ts
@@ -87,7 +87,7 @@ export class ParticleWave extends Scene {
         }
     }
 
-    draw(amplitude: number = 0, frequency: number = 440): void {
+    draw(amplitude: number = 0.1, frequency: number = 440): void {
         // Clear background
         this.p5.background(0);
         

--- a/src/scenes/StickFigures.ts
+++ b/src/scenes/StickFigures.ts
@@ -124,7 +124,7 @@ export class StickFigures extends Scene {
         }
     }
 
-    draw(amplitude: number = 0, _frequency: number = 440): void {
+    draw(amplitude: number = 0.1, _frequency: number = 440): void {
         try {
             // Clear background
             this.p5.background(0);


### PR DESCRIPTION
This PR ensures that the StickFigure and ParticleWave scenes start with low-energy movement by default, even before any audio or user interaction. The `draw` methods in both scenes are updated to use an `amplitude` of 0.1 by default, ensuring that the animations proceed with minimum movement. This resolves the issue where scenes would remain static until user input.



Created with [**Solver**](https://solverai.com)