### PR TITLE
Fix stick figures initial visibility on mobile

### DIFF
--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -78,6 +78,14 @@ export class App extends Manager {
       sceneManager.windowResized();
     });
 
+    // Ensure touch events are handled properly
+    document.addEventListener('touchstart', (e) => {
+      // Prevent default only if touching the canvas
+      if (e.target instanceof HTMLCanvasElement) {
+        e.preventDefault();
+      }
+    }, { passive: false });
+
     // Listen for visibility change to pause/resume audio
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,21 +66,35 @@ const sketch = (p: p5): void => {
         }
     };
 
-    // Add mouse move handler for audio control
-    p.mouseMoved = function(): void {
+    // Add mouse move and touch handlers for audio control
+    const handleInteraction = (x: number, y: number): void => {
         try {
             if (window.sceneManager && 
                 window.audioManager && 
                 window.audioManager.isInitialized() &&
                 window.audioManager.isPlaying) {
-                const freq = p.map(p.mouseX, 0, p.width, 200, 800);
-                const amp = p.map(p.mouseY, 0, p.height, 1, 0);
+                const freq = p.map(x, 0, p.width, 200, 800);
+                const amp = p.map(y, 0, p.height, 1, 0);
                 window.audioManager.setFrequency(freq);
                 window.audioManager.setAmplitude(amp);
             }
         } catch (error) {
-            console.error('Error handling mouse move:', error);
+            console.error('Error handling interaction:', error);
         }
+    };
+
+    p.mouseMoved = function(): void {
+        handleInteraction(p.mouseX, p.mouseY);
+    };
+
+    // Add touch handlers
+    p.touchStarted = function(): void {
+        handleInteraction(p.touches[0]?.x || p.mouseX, p.touches[0]?.y || p.mouseY);
+    };
+
+    p.touchMoved = function(): void {
+        handleInteraction(p.touches[0]?.x || p.mouseX, p.touches[0]?.y || p.mouseY);
+        return false; // Prevent default
     };
 };
 

--- a/src/scenes/StickFigures.ts
+++ b/src/scenes/StickFigures.ts
@@ -21,8 +21,8 @@ class StickFigure {
     }
 
     draw(energy: number): void {
-        // Ensure energy is a valid number and not NaN, with minimum value
-        energy = isNaN(energy) ? 0.1 : Math.max(energy, 0.1);
+        // Ensure energy is a valid number and not NaN, with higher minimum value for better visibility
+        energy = isNaN(energy) ? 0.3 : Math.max(energy, 0.3);
         
         this.p.push();
         this.p.translate(this.x, this.y);
@@ -74,8 +74,8 @@ class StickFigure {
     }
 
     update(energy: number): void {
-        // Ensure energy is a valid number and not NaN, with minimum value
-        energy = isNaN(energy) ? 0.1 : Math.max(energy, 0.1);
+        // Ensure energy is a valid number and not NaN, with higher minimum value for better visibility
+        energy = isNaN(energy) ? 0.3 : Math.max(energy, 0.3);
         
         // Scale slightly even at low energy
         this.scale = this.p.map(energy, 0, 1, 0.9, 1.1);
@@ -124,13 +124,13 @@ export class StickFigures extends Scene {
         }
     }
 
-    draw(amplitude: number = 0.1, _frequency: number = 440): void {
+    draw(amplitude: number = 0.3, _frequency: number = 440): void {
         try {
             // Clear background
             this.p5.background(0);
 
-            // Ensure amplitude is a valid number and not NaN, with a minimum value for default animation
-            amplitude = isNaN(amplitude) ? 0.1 : Math.max(amplitude, 0.1);
+            // Ensure amplitude is a valid number and not NaN, with a higher minimum value for better default visibility
+            amplitude = isNaN(amplitude) ? 0.3 : Math.max(amplitude, 0.3);
 
             // Update and draw figures
             this.figures.forEach(figure => {


### PR DESCRIPTION
Updated stick figures to be more visible on initial load by increasing their minimum animation values. Added comprehensive touch event handling in the main app and p5.js sketch for better interaction on mobile devices. Set higher default amplitude values to enhance visibility without user interaction. This should resolve the issue of figures not appearing until touched on mobile browsers.



Created with [**Solver**](https://solverai.com)